### PR TITLE
Vagrantfile Branding

### DIFF
--- a/.env.vagrant
+++ b/.env.vagrant
@@ -1,2 +1,2 @@
 VAGRANT=true
-LOCAL_DOMAIN=mastodon.dev
+LOCAL_DOMAIN=monstodon.D

--- a/.env.vagrant
+++ b/.env.vagrant
@@ -1,2 +1,2 @@
 VAGRANT=true
-LOCAL_DOMAIN=monstodon.D
+LOCAL_DOMAIN=monstodon.test

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It is a **free, open-source social network server** based on **open web protocol
 
 **Ruby on Rails** is used for the back-end, while **React.js** and Redux are used for the dynamic front-end. A static front-end for public resources (profiles and statuses) is also provided.
 
-If you would like, you can [support the development of this project on Patreon][patreon] or [Liberapay][liberapay]. 
+If you would like, you can [support the development of this project on Patreon][patreon] or [Liberapay][liberapay].
 
 [patreon]: https://www.patreon.com/kibigo
 [liberapay]: https://liberapay.com/kibigo/
@@ -79,6 +79,8 @@ You don't need to mess with dependencies and configuration if you want to try Ma
 ## Development
 
 Please follow the [development guide](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Development-guide.md) from the documentation repository.
+
+If you are using Vagrant, note that the development URL has been changed to `monstodon.D`.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ You don't need to mess with dependencies and configuration if you want to try Ma
 
 Please follow the [development guide](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Development-guide.md) from the documentation repository.
 
-If you are using Vagrant, note that the development URL has been changed to `monstodon.D`.
+If you are using Vagrant, note that the development URL has been changed to `monstodon.test`.
+The admin account is `admin@monstodon.test` and has the usual password of `mastodonadmin`.
 
 ## Deployment
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -97,11 +97,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   end
 
-  # I changed the TLD to .D because Google owns .dev now
-  config.vm.hostname = "monstodon.D"
+  # I changed the TLD to .test because Google owns .dev now
+  config.vm.hostname = "monstodon.test"
 
   # This uses the vagrant-hostsupdater plugin, and lets you
-  # access the development site at http://monstodon.D.
+  # access the development site at http://monstodon.test.
   # To install:
   #   $ vagrant plugin install vagrant-hostsupdater
   if defined?(VagrantPlugins::HostsUpdater)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,7 +83,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/xenial64"
 
   config.vm.provider :virtualbox do |vb|
-    vb.name = "mastodon"
+    vb.name = "monstodon"
     vb.customize ["modifyvm", :id, "--memory", "2048"]
 
     # Disable VirtualBox DNS proxy to skip long-delay IPv6 resolutions.
@@ -97,10 +97,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   end
 
-  config.vm.hostname = "mastodon.dev"
+  # I changed the TLD to .D because Google owns .dev now
+  config.vm.hostname = "monstodon.D"
 
   # This uses the vagrant-hostsupdater plugin, and lets you
-  # access the development site at http://mastodon.dev.
+  # access the development site at http://monstodon.D.
   # To install:
   #   $ vagrant plugin install vagrant-hostsupdater
   if defined?(VagrantPlugins::HostsUpdater)


### PR DESCRIPTION
This lets you develop `mastodon` and `monstodon` simultaneously in separate folders.

I also changed the dev URL to ~`monstodon.D`~ `monstodon.test` because the `.dev` TLD is owned by Google.